### PR TITLE
Fix ClassCastException in ActiveChatListView

### DIFF
--- a/src/info/guardianproject/otr/app/im/app/ActiveChatListView.java
+++ b/src/info/guardianproject/otr/app/im/app/ActiveChatListView.java
@@ -63,7 +63,7 @@ public class ActiveChatListView extends LinearLayout {
     UserPresenceView mPresenceView;
     ListView mChatList;
     
-    private SavedState mSavedState; 
+    //TODO private SavedState mSavedState; 
     private ChatListAdapter mAdapter;//ChatListAdapter
     private boolean mAutoRefresh = true;
 
@@ -501,11 +501,11 @@ public class ActiveChatListView extends LinearLayout {
 
     @Override
     public void onRestoreInstanceState(Parcelable state) {
-        SavedState ss = (SavedState) state;
+        //SavedState ss = (SavedState) state;
 
-        super.onRestoreInstanceState(ss.getSuperState());
+        super.onRestoreInstanceState(state); //ss.getSuperState());
 
-        mSavedState = ss;
+        //mSavedState = ss;
     }
 
     protected void setAutoRefreshContacts(boolean isRefresh) {


### PR DESCRIPTION
onRestoreInstanceState was expecting SavedState, but onSaveInstanceState has the creation code commented out. Comment it out in the former too until further review.
