### PR TITLE
Show toast when start-/stopping encrypted chat

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -306,6 +306,9 @@
     <string name="select_link_title">Select link</string>
     <!-- Displayed when there is no active chats in the chat dashboard.-->
     <string name="empty_chat_list">No active chats.</string>
+    <!--  Toast messages when starting/stopping OTR encryption for a chat -->
+    <string name ="starting_otr_chat">Starting encrypted chat session...</string>
+    <string name ="stopping_otr_chat">Stopping encrypted chat session...</string>
 
     <!-- Add contact screen -->
     <!-- This is the title of the Add Contact Screen. -->

--- a/src/info/guardianproject/otr/app/im/app/NewChatActivity.java
+++ b/src/info/guardianproject/otr/app/im/app/NewChatActivity.java
@@ -285,7 +285,7 @@ public class NewChatActivity extends Activity {
     	//TODO OTRCHAT switch state on/off
     	
     	IOtrChatSession otrChatSession = mChatView.getOtrChatSession();
-    	String msg;
+    	int toastMsgId;
 
     	try {
 			boolean isOtrEnabled = otrChatSession.isChatEncrypted();
@@ -294,13 +294,13 @@ public class NewChatActivity extends Activity {
 			if (!isOtrEnabled) {
 				otrChatSession.startChatEncryption();
 				desiredState = true;
-				msg = new String("Starting encrypted chat session...");
+				toastMsgId = R.string.starting_otr_chat;
 			} else {
 				otrChatSession.stopChatEncryption();
 				desiredState = false;
-				msg = new String("Stopping encrypted chat session...");
+				toastMsgId = R.string.stopping_otr_chat;
 			}
-			Toast.makeText(this, msg, Toast.LENGTH_SHORT).show();
+			Toast.makeText(this, getString(toastMsgId), Toast.LENGTH_SHORT).show();
 			new OtrStateCheckerThread(desiredState).start();
 		} catch (RemoteException e) {
 			Log.d("Gibber", "error getting remote activity",e);


### PR DESCRIPTION
Instead of displaying a progress dialog simply show a toast message and perform the requested action in the background. The warning view and the options menu entry are updated once the action has been processed.

This fixes issue #42.
