### PR TITLE
fixes #1916 - ensures service is shutdown/killed after provider logout

### DIFF
--- a/src/info/guardianproject/otr/app/im/app/AccountListActivity.java
+++ b/src/info/guardianproject/otr/app/im/app/AccountListActivity.java
@@ -307,10 +307,20 @@ public class AccountListActivity extends SherlockListActivity implements View.On
                 signOut(accountId);
             }
             
-            mApp.stopImServiceIfInactive();
             
             if (mCacheWord != null)
                 mCacheWord.manuallyLock();
+            
+
+            mHandler.postDelayed(new Runnable()
+            {
+                public void run ()
+                {
+                    mApp.forceStopImService();
+                    
+                }
+            }, 2000l);
+            
             
             finish();
         }


### PR DESCRIPTION
small fix that allows user to actually "sign out all" and shutdown the service
