### PR TITLE
Bug presence not updating

### DIFF
--- a/src/info/guardianproject/otr/app/im/plugin/xmpp/XmppConnection.java
+++ b/src/info/guardianproject/otr/app/im/plugin/xmpp/XmppConnection.java
@@ -2506,7 +2506,9 @@ public class XmppConnection extends ImConnection implements CallbackHandler {
     
     private void handlePresenceChanged(org.jivesoftware.smack.packet.Presence presence) {
         
-
+        if (mConnection == null)
+            return; //sometimes presence changes are queued, and get called after we sign off
+        
         XmppAddress xaddress = new XmppAddress(presence.getFrom());
 
         if (mUser.getAddress().getBareAddress().equals(xaddress.getBareAddress())) //ignore presence from yourself


### PR DESCRIPTION
noticed that presence was not always loading in chatviews even though the contact list presence was correct.

i believe this is due to chatviews being opened before the presence data comes in, or something of that nature.

this restores the retrieval of presence when the roster list is loaded, which makes the most sense.
