### PR TITLE
Bug - properly reorg fragment saved state on dataset change

### DIFF
--- a/src/info/guardianproject/otr/app/im/app/DynamicPagerAdapter.java
+++ b/src/info/guardianproject/otr/app/im/app/DynamicPagerAdapter.java
@@ -99,7 +99,9 @@ public abstract class DynamicPagerAdapter extends PagerAdapter {
     public void notifyDataSetChanged() {
         // Fragments may have moved.  Regenerate the fragment list.
         ArrayList<Fragment> old = mFragments;
+        ArrayList<Fragment.SavedState> oldState = mSavedState;
         mFragments = new ArrayList<Fragment>();
+        mSavedState = new ArrayList<Fragment.SavedState>();
         for (int i = 0 ; i < old.size() ; i++) {
             Fragment frag = old.get(i);
             if (frag != null) {
@@ -110,14 +112,19 @@ public abstract class DynamicPagerAdapter extends PagerAdapter {
                     position = i;
                 while (mFragments.size() <= position) {
                     mFragments.add(null);
+                    mSavedState.add(null);
                 }
                 mFragments.set(position, frag);
+                if (oldState.size() > i)
+                    mSavedState.set(position, oldState.get(i));
             }
         }
         
         // The list must never shrink because other methods depend on it
-        while (mFragments.size() < old.size())
+        while (mFragments.size() < old.size()) {
             mFragments.add(null);
+            mSavedState.add(null);
+        }
         super.notifyDataSetChanged();
     }
     


### PR DESCRIPTION
Steps to reproduce original behavior:
- Turn on "don't keep activities" in developer options
- Open a chat
- Turn on OTR
- Go to home and wait a few seconds for activity to be iced
- Go back to chat
- Close chat
- Open another chat

Old behavior: the OTR state will be set to checked, causing ChatView to negotiate OTR by way of the CheckedChanged callback.

New behavior: OTR remains off.

Hopefully this also resolve the issue that Nathan experienced with OTR checked state being shown as off when it's on.
