### PR TITLE
Group Chat: ActionBar changes to non-group chat layout when non group chat is also open

### DIFF
--- a/src/info/guardianproject/otr/app/im/app/ChatView.java
+++ b/src/info/guardianproject/otr/app/im/app/ChatView.java
@@ -1334,7 +1334,10 @@ public class ChatView extends LinearLayout {
         {
             //no OTR in group chat
             mStatusWarningView.setVisibility(View.GONE);
-            
+
+            // phoenix-nz - we need to update the encryption menu state, 
+            // because it could have been set in another chat view
+            mActivity.updateEncryptionMenuState();
             return;
         }
 

--- a/src/info/guardianproject/otr/app/im/app/NewChatActivity.java
+++ b/src/info/guardianproject/otr/app/im/app/NewChatActivity.java
@@ -740,8 +740,17 @@ public class NewChatActivity extends SherlockFragmentActivity implements View.On
         {                         
             if (mChatPager.getCurrentItem() > 0)
             {
-                
-                if (cView.getOtrSessionStatus() == SessionStatus.ENCRYPTED && cView.isOtrSessionVerified())
+                // phoenix-nz - a group chat should not be shown as 'unverified' as it (currently)
+                // cannot be verified. Thus, show as neutral.
+                if (cView.isGroupChat())
+                {                    
+                    mMenu.setGroupVisible(R.id.menu_group_otr_verified,false);
+                    mMenu.setGroupVisible(R.id.menu_group_otr_unverified,false);
+                    mMenu.setGroupVisible(R.id.menu_group_otr_off,false);
+
+                    mChatPagerTitleStrip.setBackgroundResource(R.color.background_dark);
+                }
+                else if (cView.getOtrSessionStatus() == SessionStatus.ENCRYPTED && cView.isOtrSessionVerified())
                 {
                     mMenu.setGroupVisible(R.id.menu_group_otr_verified,true);
                     mMenu.setGroupVisible(R.id.menu_group_otr_unverified,false);


### PR DESCRIPTION
This is a patch for bug #3289 (https://dev.guardianproject.info/issues/3289)
