### PR TITLE
Remove Gibberbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ https://guardianproject.info/code/sqlcipher/
 2. Open the file 'BUILD' and follow the instructions
 
 ## Build Instructions
-1. For these instructions, you'll need the Android SDK and Eclipse installed. Follow instructions here: https://developer.android.com/sdk/index.html and here: https://developer.android.com/sdk/installing.html
-2. From the main Gibberbot GitHub project page (https://github.com/guardianproject/Gibberbot) grab the Gibberbot source through your method of choice.
+1. For these instructions, you'll need the 32 bit Android SDK or Eclipse installed. Follow instructions here: https://developer.android.com/sdk/index.html and here: https://developer.android.com/sdk/installing.html
+2. From the main ChatSecure GitHub project page (https://github.com/guardianproject/ChatSecureAndroid) grab the ChatSecure source through your method of choice.
 
 That's it! Generally speaking, this should be an easy project to build locally for anyone who's used Eclipse and/or ADT before. If you have any questions, don't be afraid to jump into IRC for real-time help at #guardianproject on freenode or OFTC.
 


### PR DESCRIPTION
I have build ChatSecure on Ubuntu 14.04 LTS 32bit. Due to this process I have seen some old entries for gibberbot.

Due to the fact that the aapt file is a 32bit binary I was not able to build ChatSecureAndroid on 64bit.
I have add this information also to this PR.

A detail description how I was able to build ChatSecure on Ubuntu 14.04 LTS 32bit can be find at

http://alword.wordpress.com/2014/05/16/build-own-chatsecure-android-client/

feel free to reuse the information for the Project.
