### PR TITLE
Replace ViewPagerIndicator ssh url with https url to allow anonymous checkout

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = https://github.com/n8fr8/AndroidEmojiInput.git
 [submodule "external/ViewPagerIndicator"]
 	path = external/ViewPagerIndicator
-	url = git@github.com:JakeWharton/Android-ViewPagerIndicator.git
+	url = https://github.com/JakeWharton/Android-ViewPagerIndicator.git


### PR DESCRIPTION
The url type of this repo now matches all of the others.
