### PR TITLE
add a random tag to our default XMPP resource value

### DIFF
--- a/src/info/guardianproject/otr/app/im/plugin/xmpp/XmppConnection.java
+++ b/src/info/guardianproject/otr/app/im/plugin/xmpp/XmppConnection.java
@@ -963,8 +963,6 @@ public class XmppConnection extends ImConnection implements CallbackHandler {
     { 
         Debug.onConnectionStart(); //only activates if Debug TRUE is set, so you can leave this in!
 
-        initConnection(providerSettings, userName);
-
         String userResource = providerSettings.getXmppResource();
         if (userResource.equals(ImApp.DEFAULT_XMPP_RESOURCE))
         {
@@ -972,7 +970,9 @@ public class XmppConnection extends ImConnection implements CallbackHandler {
             userResource += UUID.randomUUID().toString().substring(0,8);
             providerSettings.setXmppResource(userResource);
         }
-        
+
+        initConnection(providerSettings, userName);
+
         //disable compression based on statement by Ge0rg
         mConfig.setCompressionEnabled(false);
         


### PR DESCRIPTION
if the user is still using our default "ChatSecure" resource, then
we should append it once with a random alphanum value so that there
are no issue with more than one device with the same resource is logged in
to same server at the same time
see: https://pthree.org/2007/07/13/why-xmpp-part-2-saving-your-resources/
