### PR TITLE
Fix bugs in the build setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
       <artifactId>asmack</artifactId>
       <version>4-SNAPSHOT</version>
       <scope>system</scope>
-      <systemPath>${basedir}/libs/asmack-android-7.jar</systemPath>
+      <systemPath>${basedir}/libs/asmack-android-8.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>gp-bcc-lib</groupId>

--- a/update-ant-build.sh
+++ b/update-ant-build.sh
@@ -21,7 +21,7 @@ eval `grep '^target=' project.properties`
 projectname=`sed -n 's,.*name="app_name">\(.*\)<.*,\1,p' res/values/strings.xml`
 
 for lib in `sed -n 's,^android\.library\.reference\.[0-9][0-9]*=\(.*\),\1,p' project.properties`; do
-    android update lib-project --path $lib
+    android update lib-project --path $lib --target $target
 done
 
 android update project --path . --name $projectname --target $target --subprojects


### PR DESCRIPTION
This fixes two issues in the build setup:
* If you check out the project from scratch and run the update-ant-build.sh script with current Android build tools, it fails with the output

    ```
Error: The project either has no target set or the target is invalid.
Please provide a --target to the 'android update' command.
Error: The project either has no target set or the target is invalid.
Please provide a --target to the 'android update' command.
Updated local.properties
Updated file external/appcompat/proguard-project.txt
Error: The project either has no target set or the target is invalid.
Please provide a --target to the 'android update' command.
Updated local.properties
Updated file external/cacheword/cachewordlib/proguard-project.txt
Error: The project either has no target set or the target is invalid.
Please provide a --target to the 'android update' command.
Error: The project either has no target set or the target is invalid.
Please provide a --target to the 'android update' command.
Error: The project either has no target set or the target is invalid.
Please provide a --target to the 'android update' command.
Updated project.properties
Updated local.properties
Updated file ./build.xml
Updated file ./proguard-project.txt
Updated project.properties
Updated local.properties
Updated file ./tests/build.xml
Updated file ./tests/proguard-project.txt
```
    as there is no target parameter in the android update call. The bat file does not make this mistake.

* ``pom.xml`` mentions ``${basedir}/libs/asmack-android-7.jar``, but the project ships with ``asmack-android-8.jar``