### PR TITLE
fixes #4461 (and others) related to invalid username/jids

### DIFF
--- a/src/info/guardianproject/otr/app/im/app/AccountActivity.java
+++ b/src/info/guardianproject/otr/app/im/app/AccountActivity.java
@@ -97,6 +97,8 @@ public class AccountActivity extends ActionBarActivity {
     public final static String DEFAULT_SERVER_DUKGO = "dukgo.com";
     public final static String ONION_JABBERCCC = "okj7xc6j2szr2y75.onion";
     public final static String ONION_CALYX = "ijeeynrc6x2uy5ob.onion";
+    
+    private static final String USERNAME_ONLY_ALPHANUM = "[^A-Za-z0-9]";
 
     //    private static final int ACCOUNT_KEEP_SIGNED_IN_COLUMN = 4;
     //    private static final int ACCOUNT_LAST_LOGIN_STATE = 5;
@@ -190,9 +192,9 @@ public class AccountActivity extends ActionBarActivity {
             String authority = uri.getAuthority();
             String[] userpass_host = authority.split("@");
             String[] user_pass = userpass_host[0].split(":");
-            mUserName = user_pass[0];
+            mUserName = user_pass[0].toLowerCase(Locale.getDefault());
             String pass = user_pass[1];
-            mDomain = userpass_host[1];
+            mDomain = userpass_host[1].toLowerCase(Locale.getDefault());
             mPort = 0;
             final boolean regWithTor = i.getBooleanExtra("useTor", false);
 
@@ -671,7 +673,7 @@ public class AccountActivity extends ActionBarActivity {
     private void checkUserChanged() {
         if (mEditUserAccount != null)
         {
-            String username = mEditUserAccount.getText().toString().trim();
+            String username = mEditUserAccount.getText().toString().trim().toLowerCase();
 
             if ((!username.equals(mOriginalUserAccount)) && parseAccount(username)) {
                 //Log.i(TAG, "Username changed: " + mOriginalUserAccount + " != " + username);
@@ -687,14 +689,14 @@ public class AccountActivity extends ActionBarActivity {
     boolean parseAccount(String userField) {
         boolean isGood = true;
         String[] splitAt = userField.trim().split("@");
-        mUserName = splitAt[0];
+        mUserName = splitAt[0].replaceAll(USERNAME_ONLY_ALPHANUM, "").toLowerCase(Locale.ENGLISH);
         mDomain = "";
         mPort = 0;
 
         if (splitAt.length > 1) {
             mDomain = splitAt[1].toLowerCase(Locale.US);
             String[] splitColon = mDomain.split(":");
-            mDomain = splitColon[0];
+            mDomain = splitColon[0].toLowerCase();
             if (splitColon.length > 1) {
                 try {
                     mPort = Integer.parseInt(splitColon[1]);

--- a/src/info/guardianproject/otr/app/im/app/ImUrlActivity.java
+++ b/src/info/guardianproject/otr/app/im/app/ImUrlActivity.java
@@ -48,6 +48,7 @@ import info.guardianproject.util.SystemServices.FileInfo;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 
@@ -374,7 +375,7 @@ public class ImUrlActivity extends Activity {
             mFromAddress = data.getUserInfo();
 
             //remove username non-letters
-            mFromAddress = mFromAddress.replaceAll(USERNAME_ONLY_ALPHANUM, "");
+            mFromAddress = mFromAddress.replaceAll(USERNAME_ONLY_ALPHANUM, "").toLowerCase(Locale.ENGLISH);
 
             String chatRoom = null;
 


### PR DESCRIPTION
This should solve cases where OTR does not init when a user
creates a username with uppercase letters init (See ticket for
more detailed info). All in all, normalizing usernames before
persistence/account creation is a very good thing to do.