### PR TITLE
replace AsyncTask with AsyncTaskLoader

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:smallScreens="true" />
 
     <uses-sdk
-        android:minSdkVersion="9"
+        android:minSdkVersion="11"
         android:targetSdkVersion="21" />
 
     <uses-permission android:name="info.guardianproject.otr.app.providers.imps.permission.READ_ONLY" />


### PR DESCRIPTION
Hello, I'm doing research on Android async programming. Some articles (for example [this article](http://bon-app-etit.blogspot.com/2013/04/the-dark-side-of-asynctask.html)) mention that AsyncTask leads to memory leak and losing task result when there's a configuration change (such as orientation change). Android docs recommend [AsyncTaskLoader](http://developer.android.com/reference/android/content/AsyncTaskLoader.html) (require API level 11), which avoid the problems in AsyncTask.

I try to replace one AsyncTask with AsyncTaskLoader in `ChatSecureAndroid` in this pr (you don't have to merge). Do you think AsyncTaskLoader will work better for `ChatSecureAndroid`? I found that you already use `CursorLoader` at some places. Do you also want to replace all AsyncTask with AsyncTaskLoader?