### PR TITLE
GitHub #672 Allowing setting negative XMPP priority

### DIFF
--- a/res/xml/account_settings.xml
+++ b/res/xml/account_settings.xml
@@ -29,6 +29,7 @@
 		android:summary="@string/xmpp_resource_prio_summary"
 		android:defaultValue="20"
 		android:numeric="integer"
+		android:inputType="numberSigned"
 		android:title="@string/xmpp_resource_prio_title" />
 	<EditTextPreference android:key="pref_account_port"
 		android:title="@string/server_port"


### PR DESCRIPTION
Tested on Nexus 4 Lollipop 5.1.1 (Hardware) and Nexus S 4.3.1 (Emulator.)  The keyboard that pops up now has a negative sign available, but blocks anything but digits and the negatives sign from being entered.