### PR TITLE
add panic response

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -185,6 +185,18 @@
         <activity
             android:name=".ui.AboutActivity"
             android:exported="false" />
+        <activity
+            android:name=".app.PanicResponderActivity"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="info.guardianproject.panic.action.TRIGGER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".app.ExitActivity"
+            android:theme="@android:style/Theme.NoDisplay" />
 
         <service
             android:name=".plugin.xmpp.XmppImPlugin"

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -23,7 +23,7 @@
   
    <PreferenceCategory android:title="@string/pref_group_security_title">
   
-  <ListPreference android:title="Chat Encryption"
+  <ListPreference android:title="@string/chat_encryption_title"
     android:key="pref_security_otr_mode"
     android:entryValues="@array/otr_options_values"
     android:entries="@array/otr_options"

--- a/src/info/guardianproject/otr/app/im/app/ExitActivity.java
+++ b/src/info/guardianproject/otr/app/im/app/ExitActivity.java
@@ -1,0 +1,36 @@
+
+package info.guardianproject.otr.app.im.app;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+public class ExitActivity extends Activity {
+
+    @SuppressLint("NewApi")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
+
+        System.exit(0);
+    }
+
+    public static void exitAndRemoveFromRecentApps(Activity activity) {
+        Intent intent = new Intent(activity, ExitActivity.class);
+
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+                | Intent.FLAG_ACTIVITY_CLEAR_TASK
+                | Intent.FLAG_ACTIVITY_NO_ANIMATION);
+
+        activity.startActivity(intent);
+    }
+}

--- a/src/info/guardianproject/otr/app/im/app/NewChatActivity.java
+++ b/src/info/guardianproject/otr/app/im/app/NewChatActivity.java
@@ -982,6 +982,7 @@ public class NewChatActivity extends FragmentActivity implements View.OnCreateCo
 
                 case R.id.menu_exit:
                     WelcomeActivity.shutdownAndLock(NewChatActivity.this);
+                    ExitActivity.exitAndRemoveFromRecentApps(NewChatActivity.this);
                     return true;
 
                 case R.id.menu_add_contact:

--- a/src/info/guardianproject/otr/app/im/app/PanicResponderActivity.java
+++ b/src/info/guardianproject/otr/app/im/app/PanicResponderActivity.java
@@ -1,0 +1,31 @@
+
+package info.guardianproject.otr.app.im.app;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+public class PanicResponderActivity extends Activity {
+
+    public static final String PANIC_TRIGGER_ACTION = "info.guardianproject.panic.action.TRIGGER";
+
+    @SuppressLint("NewApi")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+        if (intent != null && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
+            WelcomeActivity.shutdownAndLock(this);
+            ExitActivity.exitAndRemoveFromRecentApps(this);
+        }
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
+    }
+}

--- a/src/info/guardianproject/otr/app/im/app/WelcomeActivity.java
+++ b/src/info/guardianproject/otr/app/im/app/WelcomeActivity.java
@@ -61,6 +61,8 @@ public class WelcomeActivity extends ThemeableActivity implements ICacheWordSubs
 
     private boolean mDoSignIn = true;
 
+    private ProgressDialog dialog;
+
     static final String[] PROVIDER_PROJECTION = { Imps.Provider._ID, Imps.Provider.NAME,
                                                  Imps.Provider.FULLNAME, Imps.Provider.CATEGORY,
                                                  Imps.Provider.ACTIVE_ACCOUNT_ID,
@@ -218,6 +220,9 @@ public class WelcomeActivity extends ThemeableActivity implements ICacheWordSubs
 
         if (mCacheWord != null)
             mCacheWord.disconnect();
+
+        if (dialog != null)
+            dialog.dismiss();
     }
 
     @Override
@@ -444,9 +449,6 @@ public class WelcomeActivity extends ThemeableActivity implements ICacheWordSubs
             e.printStackTrace();
         }
            new AsyncTask<String, Void, String>() {
-
-            private ProgressDialog dialog;
-
 
             @Override
             protected void onPreExecute() {


### PR DESCRIPTION
This adds the default "lock" panic trigger to ChatSecure.  It doesn't add any panic config screen or anything.  It also makes "Shutdown & Lock" work without crashing, and clear ChatSecure from history.